### PR TITLE
Add info to turn off preview sunlight before working with 3D shader lighting.

### DIFF
--- a/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
+++ b/tutorials/shaders/your_first_shader/your_first_3d_shader.rst
@@ -277,6 +277,7 @@ Interacting with light
 
 First, turn wireframe off. To do so, click in the upper-left of the Viewport
 again, where it says "Perspective", and select "Display Normal".
+Additionally in the 3D scene toolbar, toggle off preview sunlight.
 
 .. image:: img/normal.png
 


### PR DESCRIPTION
By default in Godot 4.3, preview sunlight is enabled and only disabled by a DirectionalLight3D being added to the scene. If you follow the guide and add an OmniLight3D, the preview sunlight stays enabled and causes a drastically different look compared to the images in the guide.

With preview sunlight (default).
![image](https://github.com/user-attachments/assets/1acffda4-c8e3-41a6-b05b-dc8baa7d548e)

Without preview sunlight.
![image](https://github.com/user-attachments/assets/d073d029-3084-4ca7-a522-fac8c13293b4)


Optionally also add an image to point out the toggle button;
![image](https://github.com/user-attachments/assets/376e785f-12ef-47b4-928d-9dce5547920c)

PR remade to correctly target `master` branch.

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
